### PR TITLE
chore: release 0.1.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,6 @@ jobs:
         id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       
-      - name: Create and push tag
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git tag v${{ steps.version.outputs.version }}
-          git push origin v${{ steps.version.outputs.version }}
-      
       - name: Install dependencies
         run: npm ci
       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial release of clustering-js
+- Initial release of clustering-tfjs
 - K-Means clustering algorithm with K-means++ initialization
 - Spectral Clustering with RBF and k-NN affinity options
 - Agglomerative Clustering with multiple linkage methods (ward, complete, average, single)
@@ -34,4 +34,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CommonJS and ES module builds
 - Zero required native dependencies (optional tfjs-node for better performance)
 
-[0.1.0]: https://github.com/yourusername/clustering-js/releases/tag/v0.1.0
+[0.1.0]: https://github.com/yourusername/clustering-tfjs/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,4 +34,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CommonJS and ES module builds
 - Zero required native dependencies (optional tfjs-node for better performance)
 
-[0.1.0]: https://github.com/yourusername/clustering-tfjs/releases/tag/v0.1.0
+[0.1.0]: https://github.com/CRJFisher/clustering-tfjs/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to clustering-js
+# Contributing to clustering-tfjs
 
-Thank you for your interest in contributing to clustering-js! This document provides guidelines and instructions for contributing to the project.
+Thank you for your interest in contributing to clustering-tfjs! This document provides guidelines and instructions for contributing to the project.
 
 ## Table of Contents
 
@@ -31,8 +31,8 @@ By participating in this project, you agree to maintain a respectful and inclusi
 2. Clone your fork locally:
 
    ```bash
-   git clone https://github.com/YOUR_USERNAME/clustering-js.git
-   cd clustering-js
+   git clone https://github.com/YOUR_USERNAME/clustering-tfjs.git
+   cd clustering-tfjs
    ```
 
 3. Install dependencies:
@@ -267,7 +267,7 @@ When completing a task, add an "Implementation Notes" section:
 ## Project Structure
 
 ```
-clustering-js/
+clustering-tfjs/
 ├── src/
 │   ├── clustering/      # Algorithm implementations
 │   ├── utils/           # Helper functions
@@ -291,4 +291,4 @@ If you have questions:
 2. Review the task documentation in `backlog/`
 3. Ask in the PR or create an issue
 
-Thank you for contributing to clustering-js!
+Thank you for contributing to clustering-tfjs!

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 clustering-js contributors
+Copyright (c) 2024 clustering-tfjs contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# clustering-js
+# clustering-tfjs
 
-[![npm version](https://badge.fury.io/js/clustering-js.svg)](https://www.npmjs.com/package/clustering-js)
+[![npm version](https://badge.fury.io/js/clustering-tfjs.svg)](https://www.npmjs.com/package/clustering-tfjs)
 [![Build Status](https://github.com/CRJFisher/clustering-js/workflows/CI/badge.svg)](https://github.com/CRJFisher/clustering-js/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
@@ -37,10 +37,10 @@ Native TypeScript implementation of clustering algorithms powered by TensorFlow.
 
 ```bash
 # Standard installation (macOS/Linux)
-npm install clustering-js @tensorflow/tfjs-node
+npm install clustering-tfjs @tensorflow/tfjs-node
 
 # Windows installation (recommended)
-npm install clustering-js @tensorflow/tfjs
+npm install clustering-tfjs @tensorflow/tfjs
 ```
 
 > **Note**: For Windows users or if you encounter native binding issues, see our [Windows Compatibility Guide](./WINDOWS_COMPATIBILITY.md). The library works with either `@tensorflow/tfjs-node` (faster, requires native bindings) or `@tensorflow/tfjs` (pure JavaScript, universal compatibility).
@@ -48,7 +48,7 @@ npm install clustering-js @tensorflow/tfjs
 ### Basic Usage
 
 ```typescript
-import { KMeans } from 'clustering-js';
+import { KMeans } from 'clustering-tfjs';
 
 // Simple example
 const kmeans = new KMeans({ nClusters: 3 });
@@ -112,7 +112,7 @@ Ratio of between-cluster to within-cluster dispersion. Range: [0, ∞), higher i
 The library includes a built-in `findOptimalClusters` function that automatically determines the optimal number of clusters:
 
 ```typescript
-import { findOptimalClusters } from 'clustering-js';
+import { findOptimalClusters } from 'clustering-tfjs';
 
 // Find optimal k between 2 and 10 clusters
 const result = await findOptimalClusters(data, {
@@ -231,7 +231,7 @@ labels = kmeans.fit_predict(X)
 
 ```typescript
 // clustering-js
-import { KMeans } from 'clustering-js';
+import { KMeans } from 'clustering-tfjs';
 const kmeans = new KMeans({ nClusters: 3 });
 const labels = await kmeans.fitPredict(X);
 ```

--- a/WINDOWS_COMPATIBILITY.md
+++ b/WINDOWS_COMPATIBILITY.md
@@ -8,14 +8,14 @@ This library uses TensorFlow.js for high-performance numerical computations. On 
 
 #### Linux/macOS
 ```bash
-npm install clustering-js @tensorflow/tfjs-node
+npm install clustering-tfjs @tensorflow/tfjs-node
 ```
 
 #### Windows
 Due to native binding compilation issues on Windows, we recommend using the pure JavaScript backend:
 
 ```bash
-npm install clustering-js @tensorflow/tfjs
+npm install clustering-tfjs @tensorflow/tfjs
 ```
 
 If you encounter errors like "The specified module could not be found" or "tfjs_binding.node", this is because `@tensorflow/tfjs-node` requires native bindings that may fail to compile on Windows.

--- a/backlog/config.yml
+++ b/backlog/config.yml
@@ -1,4 +1,4 @@
-project_name: "clustering-js"
+project_name: "clustering-tfjs"
 default_status: "To Do"
 statuses: ["To Do", "In Progress", "Done"]
 labels: []

--- a/backlog/tasks/task-25 - Update-all-references-from-clustering-js-to-clustering-tfjs.md
+++ b/backlog/tasks/task-25 - Update-all-references-from-clustering-js-to-clustering-tfjs.md
@@ -1,0 +1,19 @@
+---
+id: task-25
+title: Update all references from clustering-js to clustering-tfjs
+status: To Do
+assignee: []
+created_date: '2025-07-31'
+labels: []
+dependencies: []
+---
+
+## Description
+
+Update package name references throughout the codebase including documentation, examples, and configuration files
+
+## Acceptance Criteria
+
+- [ ] All references to clustering-js updated
+- [ ] README updated with new package name
+- [ ] Documentation reflects new npm install command

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Complete API documentation for clustering-js.
+Complete API documentation for clustering-tfjs.
 
 ## Table of Contents
 
@@ -55,7 +55,7 @@ new KMeans(params: KMeansParams)
 #### Example
 
 ```typescript
-import { KMeans } from 'clustering-js';
+import { KMeans } from 'clustering-tfjs';
 
 const kmeans = new KMeans({
   nClusters: 3,
@@ -96,7 +96,7 @@ new SpectralClustering(params: SpectralClusteringParams)
 #### Example
 
 ```typescript
-import { SpectralClustering } from 'clustering-js';
+import { SpectralClustering } from 'clustering-tfjs';
 
 const spectral = new SpectralClustering({
   nClusters: 2,
@@ -127,7 +127,7 @@ new AgglomerativeClustering(params: AgglomerativeParams)
 #### Example
 
 ```typescript
-import { AgglomerativeClustering } from 'clustering-js';
+import { AgglomerativeClustering } from 'clustering-tfjs';
 
 const agglo = new AgglomerativeClustering({
   nClusters: 3,
@@ -162,7 +162,7 @@ Silhouette score (range: [-1, 1], higher is better)
 #### Example
 
 ```typescript
-import { KMeans, silhouetteScore } from 'clustering-js';
+import { KMeans, silhouetteScore } from 'clustering-tfjs';
 
 const kmeans = new KMeans({ nClusters: 3 });
 const labels = await kmeans.fitPredict(data);
@@ -245,7 +245,7 @@ function findOptimalClusters(
 #### Example
 
 ```typescript
-import { findOptimalClusters } from 'clustering-js';
+import { findOptimalClusters } from 'clustering-tfjs';
 
 const result = await findOptimalClusters(data, {
   minClusters: 2,

--- a/docs/examples/basic-usage.md
+++ b/docs/examples/basic-usage.md
@@ -1,17 +1,17 @@
 # Basic Usage Examples
 
-This guide provides practical examples for using clustering-js in common scenarios.
+This guide provides practical examples for using clustering-tfjs in common scenarios.
 
 ## Installation
 
 ```bash
-npm install clustering-js
+npm install clustering-tfjs
 ```
 
 ## Simple K-Means Example
 
 ```typescript
-import { KMeans } from 'clustering-js';
+import { KMeans } from 'clustering-tfjs';
 
 // Sample 2D data points
 const data = [
@@ -40,7 +40,7 @@ basicKMeans();
 ## Finding Optimal Number of Clusters
 
 ```typescript
-import { findOptimalClusters } from 'clustering-js';
+import { findOptimalClusters } from 'clustering-tfjs';
 
 async function findBestK() {
   const data = [
@@ -68,7 +68,7 @@ async function findBestK() {
 ## Working with Different Data Formats
 
 ```typescript
-import { KMeans } from 'clustering-js';
+import { KMeans } from 'clustering-tfjs';
 import * as tf from '@tensorflow/tfjs-node';
 
 async function differentDataFormats() {
@@ -92,7 +92,7 @@ async function differentDataFormats() {
 ## Spectral Clustering for Non-Convex Shapes
 
 ```typescript
-import { SpectralClustering } from 'clustering-js';
+import { SpectralClustering } from 'clustering-tfjs';
 
 async function spectralExample() {
   // Generate two half-moons (non-convex shapes)
@@ -126,7 +126,7 @@ async function spectralExample() {
 ## Hierarchical Clustering
 
 ```typescript
-import { AgglomerativeClustering } from 'clustering-js';
+import { AgglomerativeClustering } from 'clustering-tfjs';
 
 async function hierarchicalExample() {
   // Customer segmentation data
@@ -172,7 +172,7 @@ async function hierarchicalExample() {
 ## Evaluating Clustering Quality
 
 ```typescript
-import { KMeans, silhouetteScore, daviesBouldin, calinskiHarabasz } from 'clustering-js';
+import { KMeans, silhouetteScore, daviesBouldin, calinskiHarabasz } from 'clustering-tfjs';
 
 async function evaluateClustering() {
   const data = [
@@ -208,7 +208,7 @@ async function evaluateClustering() {
 ## Handling Large Datasets
 
 ```typescript
-import { KMeans } from 'clustering-js';
+import { KMeans } from 'clustering-tfjs';
 import * as tf from '@tensorflow/tfjs-node';
 
 async function largeDatesetClustering() {
@@ -249,7 +249,7 @@ async function largeDatesetClustering() {
 ## Custom Distance Metrics (Using Spectral)
 
 ```typescript
-import { SpectralClustering } from 'clustering-js';
+import { SpectralClustering } from 'clustering-tfjs';
 
 async function customAffinityExample() {
   // Time series data
@@ -277,7 +277,7 @@ async function customAffinityExample() {
 ## Error Handling
 
 ```typescript
-import { KMeans } from 'clustering-js';
+import { KMeans } from 'clustering-tfjs';
 
 async function robustClustering() {
   const data = [[1, 2], [3, 4]];  // Only 2 points

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "clustering-js",
+  "name": "clustering-tfjs",
   "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "clustering-js",
+      "name": "clustering-tfjs",
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clustering-tfjs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clustering-tfjs",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@tensorflow/tfjs": "^4.20.0",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "browser",
     "nodejs"
   ],
-  "homepage": "https://github.com/yourusername/clustering-js#readme",
+  "homepage": "https://github.com/CRJFisher/clustering-tfjs#readme",
   "bugs": {
-    "url": "https://github.com/yourusername/clustering-js/issues"
+    "url": "https://github.com/CRJFisher/clustering-tfjs/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/yourusername/clustering-js.git"
+    "url": "git+https://github.com/CRJFisher/clustering-tfjs.git"
   },
   "license": "MIT",
   "author": "Your Name <your.email@example.com>",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "clustering-js",
+  "name": "clustering-tfjs",
   "version": "0.1.2",
   "description": "High-performance TypeScript clustering algorithms (K-Means, Spectral, Agglomerative) with TensorFlow.js acceleration and scikit-learn compatibility",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clustering-tfjs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "High-performance TypeScript clustering algorithms (K-Means, Spectral, Agglomerative) with TensorFlow.js acceleration and scikit-learn compatibility",
   "keywords": [
     "clustering",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -206,10 +206,11 @@ async function release() {
 ${releaseNotes}
 
 ---
-This PR was created automatically by the release script. Once merged, it will trigger the release workflow which will:
-1. Create git tag (v${version})
-2. Publish to npm
-3. Create GitHub release`;
+This PR was created automatically by the release script. The tag ${tagName} has already been created and pushed.
+
+Once merged, the release workflow will:
+1. Publish to npm
+2. Create GitHub release with tag ${tagName}`;
   
   fs.writeFileSync(tempFile, prBody);
   

--- a/src/utils/findOptimalClusters.ts
+++ b/src/utils/findOptimalClusters.ts
@@ -53,7 +53,7 @@ export interface FindOptimalClustersOptions {
  *
  * @example
  * ```typescript
- * import { findOptimalClusters } from 'clustering-js';
+ * import { findOptimalClusters } from 'clustering-tfjs';
  *
  * const data = [[1, 2], [1.5, 1.8], [5, 8], [8, 8], [1, 0.6], [9, 11]];
  * const result = await findOptimalClusters(data, { maxClusters: 5 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 // Central re-export hub for utility helpers.  This allows external code to
-// import from "clustering-js/utils" instead of deep paths.
+// import from "clustering-tfjs/utils" instead of deep paths.
 
 export { pairwiseDistanceMatrix } from './pairwise_distance';
 export { degree_vector, normalised_laplacian } from './laplacian';


### PR DESCRIPTION
## Release v0.1.3

Rename package to clustering-tfjs

- Package renamed from clustering-js to clustering-tfjs  
- clustering-tfjs is available on npm (clustering-js was taken)
- Updated all documentation and code references
- Updated repository URLs to match new name
- This is the first release under the new name

---
This PR was created automatically by the release script. The tag v0.1.3 has already been created and pushed.

Once merged, the release workflow will:
1. Publish to npm
2. Create GitHub release with tag v0.1.3