### PR TITLE
chore: release 0.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm test
       
       - name: Build package
-        run: npm run build
+        run: npm run build:multi
       
       - name: Verify all platform builds
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clustering-tfjs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clustering-tfjs",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@tensorflow/tfjs-core": "^4.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clustering-tfjs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "High-performance TypeScript clustering algorithms (K-Means, Spectral, Agglomerative) with TensorFlow.js acceleration and scikit-learn compatibility",
   "keywords": [
     "clustering",


### PR DESCRIPTION
## Release v0.3.1

Fix release workflow to use multi-platform build command

---
This PR was created automatically by the release script. The tag v0.3.1 has already been created and pushed.

Once merged, the release workflow will:
1. Publish to npm
2. Create GitHub release with tag v0.3.1