### PR TITLE
chore: release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-06-25
+
+### Changed
+
+- **HDBSCAN front-half on tensors.** The k-distance / mutual-reachability /
+  minimum-spanning-tree stage now runs on TensorFlow.js ops, giving a
+  2.9–12.6× speedup with `tfjs-node` across all measured input sizes. Cluster
+  labels are unchanged; per-point `probabilities_` may differ within float32
+  tolerance.
+
+### Removed
+
+- Dead `kdistance` module and fixtures, superseded by the tensor front-half.
+- Internal-only `MatrixFreeOperator` and `SparseNormalisedLaplacian` exports
+  made package-private. No public API change.
+
+### Internal
+
+- Comments across the codebase normalized to WHY-only; AGENTS/CLAUDE
+  conventions consolidated.
+
 ## [0.6.0] - 2026-06-22
 
 ### Added

--- a/jest.coverage.config.js
+++ b/jest.coverage.config.js
@@ -20,7 +20,6 @@ const GATED_MODULES = [
   'src/clustering/hdbscan.ts',
   'src/clustering/medoid_selection.ts',
   'src/decomposition/pca.ts',
-  'src/distance/kdistance.ts',
   'src/graph/condensation_tree.ts',
   'src/graph/minimum_spanning_tree.ts',
   'src/graph/mutual_reachability.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clustering-tfjs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clustering-tfjs",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "devDependencies": {
         "@tensorflow/tfjs-core": "^4.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clustering-tfjs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "High-performance TypeScript clustering algorithms (K-Means, Spectral, Agglomerative) with TensorFlow.js acceleration and scikit-learn compatibility",
   "keywords": [
     "clustering",

--- a/src/decomposition/pca.test.ts
+++ b/src/decomposition/pca.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { PCA } from '..';
-import { power_iteration_eig } from './pca';
+import { power_iteration_eig, unit_init_vector } from './pca';
 import * as tf from '../../test_support/tensorflow_helper';
 
 const FIXTURE_DIR = path.join(process.cwd(), '__fixtures__', 'pca');
@@ -173,6 +173,12 @@ describe('PCA – API behaviour', () => {
 });
 
 describe('power_iteration_eig – degenerate matrices', () => {
+  it('falls back to a basis vector when the init candidate has zero norm', () => {
+    expect(unit_init_vector([0, 0, 0], 0)).toEqual([1, 0, 0]);
+    expect(unit_init_vector([0, 0, 0], 4)).toEqual([0, 1, 0]);
+    expect(unit_init_vector([0, 3, 4], 0)).toEqual([0, 0.6, 0.8]);
+  });
+
   it('returns zero eigenvalues for the zero matrix without iterating forever', () => {
     const { components, eigenvalues } = power_iteration_eig(
       [

--- a/src/decomposition/pca.ts
+++ b/src/decomposition/pca.ts
@@ -43,7 +43,7 @@ function to_array(X: DataMatrix): number[][] {
  * normalized, or the `c % d` standard basis vector when the candidate has
  * zero norm (so iteration always starts from a valid direction).
  */
-function unit_init_vector(candidate: number[], c: number): number[] {
+export function unit_init_vector(candidate: number[], c: number): number[] {
   const d = candidate.length;
   const vn = Math.sqrt(candidate.reduce((s, x) => s + x * x, 0));
   if (vn === 0) {


### PR DESCRIPTION
## Release v0.6.1

HDBSCAN front-half migrated to TensorFlow.js ops (2.9–12.6× faster with tfjs-node); labels unchanged, probabilities within float32 tolerance. Dead kdistance code removed and internal export surface trimmed. No public API change.

---
This PR was created automatically by the release script. The tag v0.6.1 has already been created and pushed.

Once merged, the release workflow will:
1. Publish to npm
2. Create GitHub release with tag v0.6.1